### PR TITLE
How about this approach to integrating node-harfbuzz with node-freetype2?

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -5,7 +5,7 @@
       "sources": [
         "src/harfbuzz.cc",
       ],
-      "include_dirs": ["<!(node -e \"require('nan')\")", "/usr/local/include/freetype2", "/usr/local/include/harfbuzz"],
+      "include_dirs": ["<!(node -e \"require('nan')\")", "node_modules/freetype2/src", "/usr/local/include/freetype2", "/usr/local/include/harfbuzz"],
       "libraries": [ "-lfreetype", "-lharfbuzz" ]
     }
   ]

--- a/examples/index.js
+++ b/examples/index.js
@@ -11,5 +11,5 @@ var device_vdpi = 72;
 ft.Set_Char_Size(face, 0, ptSize, device_hdpi, device_vdpi );
 
 var hb = require('../index.js');
-var glyphs = hb(face.handle, process.argv[3]);
+var glyphs = hb(face, process.argv[3]);
 console.log(glyphs);

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "main": "index.js",
   "gypfile": true,
   "dependencies": {
+    "freetype2": "^0.3.0",
     "nan": "^2.0.9"
   }
 }

--- a/src/harfbuzz.cc
+++ b/src/harfbuzz.cc
@@ -4,6 +4,7 @@
 #include <sstream>
 #include <string>
 #include <nan.h>
+#include <FontFace.h>
 
 #include <iostream>
 
@@ -16,18 +17,11 @@ using v8::Number;
 using v8::Array;
 
 NAN_METHOD(Shape) {
-
-  String::Utf8Value ftHandle(info[0]->ToString());
+  FontFace* fontFace = node::ObjectWrap::Unwrap<FontFace>(info[0]->ToObject());
   String::Utf8Value input(info[1]->ToString());
 
-  std::stringstream ss;
-  ss << std::hex << *ftHandle;
-  unsigned long ptr;
-  ss >> ptr;
-  FT_Face ft_face = reinterpret_cast<FT_Face>(ptr);
-
   hb_buffer_t *buf = hb_buffer_create();
-  hb_font_t *hb_ft_font = hb_ft_font_create(ft_face, NULL);
+  hb_font_t *hb_ft_font = hb_ft_font_create(fontFace->ftFace, NULL);
   //hb_buffer_set_direction(buf, HB_DIRECTION_LTR);
   hb_buffer_set_direction(buf, HB_DIRECTION_RTL);
   //hb_buffer_set_script(buf, "en");


### PR DESCRIPTION
- Add freetype2 as a dependency.
- Include the `FontFace.h` header in `harfbuzz.c`.
- In the example js, pass the `FontFace` object from freetype2 directly into the harfbuzz function.
- In harfbuzz, access the `FT_Face` directly.
