### PR TITLE
Remove FreeType dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,22 +2,27 @@
 
 node.js [harfbuzz](https://github.com/behdad/harfbuzz) bindings
 
-# Example
+# Examples
+
+Works with fonts loaded from buffers
 
 ```js
 var fs = require('fs');
-var ft = require('freetype2');
+var hb = require('../index.js');
 
-var face = {};
-ft.New_Memory_Face(fs.readFileSync(process.argv[2]), 0, face);
-face = face.face;
+var font = hb.createFont(fs.readFileSync(process.argv[2]), 64);
+var glyphs = hb.shape(font, process.argv[3]);
 
-var ptSize = 70*64;
-var device_hdpi = 72;
-var device_vdpi = 72;
-ft.Set_Char_Size(face, 0, ptSize, device_hdpi, device_vdpi );
+console.log(glyphs);
+```
 
-var hb = require('harfbuzz');
-var glyphs = hb(face.handle, "This is test text to shape");
+Also loads fonts from disk as a convenience
+
+```js
+var hb = require('../index.js');
+
+var font = hb.createFont(process.argv[2], 64);
+var glyphs = hb.shape(font, process.argv[3]);
+
 console.log(glyphs);
 ```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Works with fonts loaded from buffers
 
 ```js
 var fs = require('fs');
-var hb = require('../index.js');
+var hb = require('harfbuzz');
 
 var font = hb.createFont(fs.readFileSync(process.argv[2]), 64);
 var glyphs = hb.shape(font, process.argv[3]);
@@ -19,7 +19,7 @@ console.log(glyphs);
 Also loads fonts from disk as a convenience
 
 ```js
-var hb = require('../index.js');
+var hb = require('harfbuzz');
 
 var font = hb.createFont(process.argv[2], 64);
 var glyphs = hb.shape(font, process.argv[3]);

--- a/binding.gyp
+++ b/binding.gyp
@@ -5,8 +5,8 @@
       "sources": [
         "src/harfbuzz.cc",
       ],
-      "include_dirs": ["<!(node -e \"require('nan')\")", "/usr/local/include/freetype2", "/usr/local/include/harfbuzz"],
-      "libraries": [ "-lfreetype", "-lharfbuzz" ]
+      "include_dirs": ["<!(node -e \"require('nan')\")", "/usr/local/include/harfbuzz"],
+      "libraries": [ "-lharfbuzz" ]
     }
   ]
 }

--- a/examples/index.js
+++ b/examples/index.js
@@ -1,15 +1,7 @@
 var fs = require('fs');
-var ft = require('freetype2');
-
-var face = {};
-ft.New_Memory_Face(fs.readFileSync(process.argv[2]), 0, face);
-face = face.face;
-
-var ptSize = 70*64;
-var device_hdpi = 72;
-var device_vdpi = 72;
-ft.Set_Char_Size(face, 0, ptSize, device_hdpi, device_vdpi );
-
 var hb = require('../index.js');
-var glyphs = hb(face.handle, process.argv[3]);
+
+var font = hb.createFont(fs.readFileSync(process.argv[2]), 64);
+var glyphs = hb.shape(font, process.argv[3]);
+
 console.log(glyphs);

--- a/index.js
+++ b/index.js
@@ -6,7 +6,34 @@
  * MIT License <https://github.com/rvagg/nan/blob/master/LICENSE.md>
  ********************************************************************/
 
-var addon = require('./build/Release/addon');
-module.exports = function(ftFaceHandle, text) {
-  return addon.shape(ftFaceHandle, text);
-};
+var addon = require('./build/Release/addon'),
+    util = require("util"),
+    fs = require("fs");
+
+module.exports = {
+  createFont: function(font, size) {
+    var f;
+    if(Buffer.isBuffer(font)) {
+      f = new addon.HarfBuzzFont(font, size);
+      f[util.inspect.custom] = function(depth) { return `HarfBuzzFont { size: ${size} }`; }
+      
+    } else if(typeof font == "string") {
+      var buffer = fs.readFileSync(font);
+      f = new addon.HarfBuzzFont(buffer, size);
+      Object.defineProperty(f, "file", {value: font, writeable: false });
+      f[util.inspect.custom] = function(depth) { return `HarfBuzzFont { size: ${size}, file: ${util.inspect(font)} }`; }
+      
+    } else {
+      throw "Font must be either a file name string or a buffer"
+      
+    }
+    
+    Object.defineProperty(f, "size", {value: size, writeable: false });
+    
+    return f;
+  },
+  
+  shape: function(font, text) {
+    return addon.shape(font, text);
+  }
+}

--- a/src/harfbuzz.cc
+++ b/src/harfbuzz.cc
@@ -1,5 +1,5 @@
 #include "hb.h"
-#include "hb-ft.h"
+#include "hb-ot.h"
 
 #include <sstream>
 #include <string>
@@ -15,34 +15,77 @@ using v8::String;
 using v8::Number;
 using v8::Array;
 
+class HarfBuzzFont : public Nan::ObjectWrap {
+public:
+  hb_font_t* _font;
+  unsigned int _size;
+  
+  static NAN_MODULE_INIT(Init) {
+    v8::Local<v8::FunctionTemplate> tpl = Nan::New<v8::FunctionTemplate>(New);
+    tpl->SetClassName(Nan::New("HarfBuzzFont").ToLocalChecked());
+    tpl->InstanceTemplate()->SetInternalFieldCount(1);
+    
+    constructor().Reset(Nan::GetFunction(tpl).ToLocalChecked());
+    Nan::Set(target, Nan::New("HarfBuzzFont").ToLocalChecked(),
+      Nan::GetFunction(tpl).ToLocalChecked());
+  }
+    
+  static NAN_METHOD(New) {
+    if (info.IsConstructCall()) {
+      char* fontFileBuffer = (char*) node::Buffer::Data(info[0]->ToObject());
+      size_t fontFileBufferLength = node::Buffer::Length(info[0]->ToObject());
+      unsigned int fontSize = info[1]->Uint32Value();  
+      
+      hb_blob_t* blob = hb_blob_create(fontFileBuffer, fontFileBufferLength, HB_MEMORY_MODE_READONLY, NULL, NULL);
+      hb_face_t* face = hb_face_create(blob, 0);
+      hb_font_t* font = hb_font_create(face);
+
+      hb_ot_font_set_funcs(font);
+      hb_font_set_scale(font, fontSize, fontSize);
+      
+      HarfBuzzFont *obj = new HarfBuzzFont(font, fontSize);
+      obj->Wrap(info.This());
+      info.GetReturnValue().Set(info.This());
+      
+    } else {
+      const int argc = 2;
+      v8::Local<v8::Value> argv[argc] = {info[0], info[1]};
+      v8::Local<v8::Function> cons = Nan::New(constructor());
+      info.GetReturnValue().Set(Nan::NewInstance(cons, argc, argv).ToLocalChecked());
+    }
+  }
+        
+  static inline Nan::Persistent<v8::Function> & constructor() {
+    static Nan::Persistent<v8::Function> my_constructor;
+    return my_constructor;
+  }
+  
+  explicit HarfBuzzFont(hb_font_t* font, unsigned int size) : _font(font), _size(size) {}
+};
+
 NAN_METHOD(Shape) {
-
-  String::Utf8Value ftHandle(info[0]->ToString());
+  HarfBuzzFont* font = Nan::ObjectWrap::Unwrap<HarfBuzzFont>(info[0]->ToObject());
   String::Utf8Value input(info[1]->ToString());
-
-  std::stringstream ss;
-  ss << std::hex << *ftHandle;
-  unsigned long ptr;
-  ss >> ptr;
-  FT_Face ft_face = reinterpret_cast<FT_Face>(ptr);
-
+  
   hb_buffer_t *buf = hb_buffer_create();
-  hb_font_t *hb_ft_font = hb_ft_font_create(ft_face, NULL);
-  //hb_buffer_set_direction(buf, HB_DIRECTION_LTR);
-  hb_buffer_set_direction(buf, HB_DIRECTION_RTL);
-  //hb_buffer_set_script(buf, "en");
 
-  int len = strlen(*input);
-  hb_buffer_add_utf8(buf, *input, len, 0, len);
-  hb_shape(hb_ft_font, buf, NULL, 0);
+  hb_buffer_add_utf8(buf, *input, -1, 0, -1);
+  hb_buffer_guess_segment_properties (buf);
+  hb_shape(font->_font, buf, NULL, 0);
 
-  unsigned int         glyph_count;
-  hb_glyph_info_t     *glyph_info   = hb_buffer_get_glyph_infos(buf, &glyph_count);
-  hb_glyph_position_t *glyph_pos    = hb_buffer_get_glyph_positions(buf, &glyph_count);
+  unsigned int        glyph_count = hb_buffer_get_length (buf);
+  hb_glyph_info_t     *glyph_info = hb_buffer_get_glyph_infos(buf, NULL);
+  hb_glyph_position_t *glyph_pos  = hb_buffer_get_glyph_positions(buf, NULL);
 
   Local<Array> glyphs = Nan::New<Array>(glyph_count);
   for (size_t i = 0; i < glyph_count; i++) {
     Local<Object> g = Nan::New<Object>();
+    
+    hb_codepoint_t gid = glyph_info[i].codepoint;
+    char glyphname[32];
+    hb_font_get_glyph_name (font->_font, gid, glyphname, sizeof (glyphname));
+    
+    g->Set(Nan::New("name").ToLocalChecked(), Nan::New<String>(glyphname).ToLocalChecked());
     g->Set(Nan::New("xOffset").ToLocalChecked(), Nan::New<Number>(glyph_pos[i].x_offset));
     g->Set(Nan::New("yOffset").ToLocalChecked(), Nan::New<Number>(glyph_pos[i].y_offset));
     g->Set(Nan::New("xAdvance").ToLocalChecked(), Nan::New<Number>(glyph_pos[i].x_advance));
@@ -53,11 +96,13 @@ NAN_METHOD(Shape) {
 
     glyphs->Set(i, g);
   }
+  
   info.GetReturnValue().Set(glyphs);
 }
 
 void InitAll(Handle<Object> exports) {
   exports->Set(Nan::New<String>("shape").ToLocalChecked(), Nan::New<FunctionTemplate>(Shape)->GetFunction());
+  HarfBuzzFont::Init(exports);
 }
 
-NODE_MODULE(addon, InitAll)
+NODE_MODULE(harfbuzz, InitAll)


### PR DESCRIPTION
Use HarfBuzz's internal opentype implementation to parse font files,
which reduces the complexity of the package and makes it more self
contained.